### PR TITLE
Collapse dataset panels by default

### DIFF
--- a/src/store/index.js
+++ b/src/store/index.js
@@ -89,7 +89,7 @@ function createStore(injected) {
       panels: {},
       cameraViewPoints: {},
       mostRecentViewPoint: null,
-      collapseDatasetPanels: false,
+      collapseDatasetPanels: true,
       suppressBrowserWarning: false,
     },
     getters: {


### PR DESCRIPTION
As requested, dataset panels are now collapsed by default